### PR TITLE
Allow HTML to be outputted in place of simple text string

### DIFF
--- a/src/templates/front-end/cart-link.twig
+++ b/src/templates/front-end/cart-link.twig
@@ -1,8 +1,9 @@
 {% set classes = classes ?? [] -%}
 {% set href = href ?? '#' -%}
 {% set showCount = showCount ?? true -%}
+{% set text = text ?? "Shopping Cart"|t %}
 {% if craft.snipcart.publicApiKey -%}
     <a id="snipcart-cart-link" href="{{ href }}" class="snipcart-checkout snipcart-summary{% if classes | length %} {{ classes | join(' ') }}{% endif %}">
-        {{- text|raw ?? "Shopping Cart"|t }}{% if showCount %} <span id="snipcart-item-count" class="snipcart-total-items">0</span>{% endif -%}
+        {{- text|raw }}{% if showCount %} <span id="snipcart-item-count" class="snipcart-total-items">0</span>{% endif -%}
     </a>
 {%- endif %}

--- a/src/templates/front-end/cart-link.twig
+++ b/src/templates/front-end/cart-link.twig
@@ -3,6 +3,6 @@
 {% set showCount = showCount ?? true -%}
 {% if craft.snipcart.publicApiKey -%}
     <a id="snipcart-cart-link" href="{{ href }}" class="snipcart-checkout snipcart-summary{% if classes | length %} {{ classes | join(' ') }}{% endif %}">
-        {{- text ?? "Shopping Cart"|t }}{% if showCount %} <span id="snipcart-item-count" class="snipcart-total-items">0</span>{% endif -%}
+        {{- text|raw ?? "Shopping Cart"|t }}{% if showCount %} <span id="snipcart-item-count" class="snipcart-total-items">0</span>{% endif -%}
     </a>
 {%- endif %}


### PR DESCRIPTION
There are times when you do not want to output a simple text string for the cart link, but rather usually an icon, or potentially any other HTML structure you can think of. 

```
{% set tag = '<i class="fal fa-shopping-bag" aria-hidden="true"></i><span class="sr-only">Cart</span>' %}
{{ craft.snipcart.cartLink(tag, true) }}
```